### PR TITLE
Fixed the GitHub banner link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="banner.png" alt="Jumpsuit Banner" width="100%" />
+  <img src="https://raw.githubusercontent.com/jumpsuit/jumpsuit/master/banner.png" alt="Jumpsuit Banner" width="100%" />
 </div>
 
 # Jumpsuit


### PR DESCRIPTION
Unfortunately, plain `src="banner.jpg"` link leads to the https://github.com/jumpsuit/jumpsuit/blob/master/banner.png GitHub preview page, which is an HTML page, not a raw image.

This should fix the Readme rendering.
