### PR TITLE
Accepts a React component or function as option on Component

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
-export default function (options, connectFn) {
-  const container = React.createClass(options)
+export default function (component, connectFn) {
+  const container = typeof component === 'object'
+    ? React.createClass(options)
+    : component
+
   return connectFn ? connect(connectFn)(container) : container
 }


### PR DESCRIPTION
I didn't tested it yet. Can you guys help me with that? How can I run the examples?

That's a propose to accept on `Component` function, besides an object, a React component or function, e.g:

``` javascript
class MyButton extends React.Component {
  render() {
    // Something
  }
}

// or

const MyLabel = (props) => {}

// and be used as parameter for jupsuit `Component` function

Component(MyLabel)
Component(MyButton)
```
