### PR TITLE
Adjust divider to stop unnecessary page scrolling

### DIFF
--- a/packages/cli/getting-started/src/app.styl
+++ b/packages/cli/getting-started/src/app.styl
@@ -54,6 +54,8 @@ body
       background $clr-jumpsuit1
       position absolute
       right 0
+      top: 50%
+      transform: translateY(-50%)
       width 1px
       height 90%
 


### PR DESCRIPTION
Just a small fix to the styling for the getting started example. By not setting the vertical positioning of the divider it just causes the the page to have some unnecessary overflow. No biggie, just noticed when I started a new project.

**before**

![jumpsuit-before](https://cloud.githubusercontent.com/assets/2156395/17875577/19b2da6a-68cb-11e6-9cec-595bb3a77229.png)

**after**

![jumpsuit-after](https://cloud.githubusercontent.com/assets/2156395/17875578/19b38564-68cb-11e6-8ff3-3f62938da37e.png)
