### PR TITLE
partial support for lerna.js

### DIFF
--- a/packages/cli/src/cmds/build.js
+++ b/packages/cli/src/cmds/build.js
@@ -21,7 +21,7 @@ export default async function (argv) {
 
 export async function watch (argv) {
   outputLogo()
-  const { sourceDir, outputDir } = CONFIG
+  const { sourceDir, outputDir, extraDirs } = CONFIG
 
   fs.emptyDirSync(outputDir)
   const watcher = chokidar.watch(sourceDir, {
@@ -30,6 +30,21 @@ export async function watch (argv) {
   })
 
   watcher.on('all', handleEvent)
+
+  // extra watchers:
+  const extraWatchers = extraDirs.map((f)=>{
+    return chokidar.watch(f, {
+      persistent: true,
+      ignored: /[\/\\](\.)|node_modules|bower_components/
+    })
+  })
+
+  extraWatchers.forEach((w)=>{
+    w.on('all', handleEvent)
+  })
+
+  // extra watchers end
+
   await serve(argv, true)
 }
 

--- a/packages/cli/src/utils/config.js
+++ b/packages/cli/src/utils/config.js
@@ -10,6 +10,8 @@ const defaults = {
   outputDir: 'dist',
   assetsDir: 'assets', // relative to sourceDir
 
+  extraDirs:[],
+
   assetsIgnoreExtensions: [],
 
   entry: 'app.js', // relative to sourceDir
@@ -51,6 +53,7 @@ export default async function (argv) {
   config.outputDir = convertIfWin32Path(path.resolve(config.outputDir))
   config.assetsDir = convertIfWin32Path(path.resolve(config.sourceDir, config.assetsDir))
   config.entry = convertIfWin32Path(path.resolve(config.sourceDir, config.entry))
+  config.extraDirs = config.extraDirs.map( (f) => convertIfWin32Path(path.resolve(f)))
 
   CONFIG = config
 }


### PR DESCRIPTION
This adds support for extra source dirs outside of standard sourceDirs. 
It can be a first step for multi-package setup, eg. using lernajs.

Currently I use ugly solution: including sources from other package(s) by pointing them directly - using single centralized includes.js, eg:
`
  export {Geostreaming,states  } from '../../../react-geostreaming/src/GeostreamingApp';
`
With all it's downsides, it allows at least to use HSR for dev while making possible to build / package other package(s) independently.

If you can provide better alternative, please ignore this pull.
