### PR TITLE
Minor correction to Hook documentation in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,14 +250,14 @@ To create a global effect:
 import { Hook } from 'jumpsuit'
 
 // You can hook into any actions, even ones from external libraries!
-const myEffect = Hook((action, getState) => {
+const myHook = Hook((action, getState) => {
   if (action.type === 'redux-form/INITIALIZE') {
     console.log('A Redux-Form was just initialized with this payload', payload)
   }
 })
 
 // Load google analytics if it is not found
-const myEffect = Hook((action, getState) => {
+const analyticsHook = Hook((action, getState) => {
   GoogleAnalytics('send', 'page', payload.pathname)
 })
 ```

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ import { Effect, Actions } from 'jumpsuit'
 const postFetchEffect = Effect('postsFetch', (payload) => {
   // You can do anything here, but async actions are a great use case:
   Actions.showLoading(true)
-  Axio.get('http://mysite.com/posts')
+  Axios.get('http://mysite.com/posts')
     .then(Actions.postsFetchSuccess)
     .catch(Actions.postsFetchError)
     .finally(() => Actions.showLoading(false))
@@ -250,7 +250,7 @@ To create a global effect:
 import { Hook } from 'jumpsuit'
 
 // You can hook into any actions, even ones from external libraries!
-const myEffect = Effect((action, getState) => {
+const myEffect = Hook((action, getState) => {
   if (action.type === 'redux-form/INITIALIZE') {
     console.log('A Redux-Form was just initialized with this payload', payload)
   }


### PR DESCRIPTION
The readme had `Effect` instead of `Hook` in one of the code examples.
Both Hook const variables had the same name
As a bonus, I've corrected `Axio` to `Axios`!