### PR TITLE
fix Goto.back, add Goto.forward, export syncedHistory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import {
 } from 'react-router'
 
 import Component from './component'
-import Render, { Router } from './render'
+import Render, { Router, syncedHistory } from './render'
 import { State, Effect, Hook, Actions, StateDefaults, getState, dispatch } from 'jumpstate'
 import Goto from './routing'
 import { Middleware, Enhancer } from './reducer'
@@ -31,6 +31,7 @@ module.exports = {
   Link,
   IndexLink,
   Goto,
+  syncedHistory,
 
   /* Redux */
   Middleware,

--- a/src/routing.js
+++ b/src/routing.js
@@ -52,6 +52,6 @@ Goto.back = function (amount = -1) {
   return syncedHistory.go(-(Math.abs(amount)))
 }
 
-Goto.back = function (amount = 1) {
+Goto.forward = function (amount = 1) {
   return syncedHistory.go((Math.abs(amount)))
 }


### PR DESCRIPTION
`Goto.back` does not work due to what appears to be a merge conflict. Exported `syncedHistory` so that it can actually be introspected if I do not want to use `Goto`.